### PR TITLE
backup single thread

### DIFF
--- a/example/config.toml
+++ b/example/config.toml
@@ -2,8 +2,8 @@
 storage_port = 60003
 domain = "test-chain-node1"
 enable_metrics = false
-l1_capacity = 100
-l2_capacity = 2000
+l1_capacity = 200
+l2_capacity = 90000
 
 [storage_opendal.log_config]
 max_level = "info"

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,7 +77,7 @@ impl Default for StorageConfig {
             l1_capacity: 200,
             l2_capacity: 90000,
             backup_interval: 300,
-            retreat_interval: 5,
+            retreat_interval: 150,
             cloud_storage: Default::default(),
         }
     }
@@ -99,7 +99,7 @@ mod tests {
 
         assert_eq!(config.storage_port, 60003);
         assert_eq!(config.domain, "test-chain-node1");
-        assert_eq!(config.l1_capacity, 100);
-        assert_eq!(config.l2_capacity, 2000);
+        assert_eq!(config.l1_capacity, 200);
+        assert_eq!(config.l2_capacity, 90000);
     }
 }


### PR DESCRIPTION
当一个区块中交易比较多的时候，因为原来的代码中是每个key-value都启动一个线程去并发写，所以会触发s3的流控，导致backup失败。
因为每次尝试都会因为同样的原因失败，所以backup进程就被卡在这个高度无法进行下去。

---

原来并发写入方案主要考虑的是从老的没有使用s3的链切换到使用s3的时候尽快同步到比较新的高度。
但是我们不能假设用户使用的s3的性能和并发处理能力，为了可靠性，只能舍弃速度，改为单线程备份。
s3功能就只针对冷热数据分离的场景。
老链迁移场景，可以提前增加只读节点进行同步，或者先通过其他方式迁移，然后再加上s3，让它慢慢备份。
